### PR TITLE
Patch xresources

### DIFF
--- a/patches/st-xresources-signal-reloading-20220407-ef05519.diff
+++ b/patches/st-xresources-signal-reloading-20220407-ef05519.diff
@@ -1,0 +1,153 @@
+From b2a9c96cc3c9152c4e8188f341606c914741cb50 Mon Sep 17 00:00:00 2001
+From: wael <40663@protonmail.com>
+Date: Thu, 7 Apr 2022 17:14:02 +0300
+Subject: [PATCH] fix xresources with signal reloading removing arg.h and st.h
+ & remove unneccesary xresources variables(?)
+
+---
+ x.c | 115 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 115 insertions(+)
+
+diff --git a/x.c b/x.c
+index 2a3bd38..e8fe7ad 100644
+--- a/x.c
++++ b/x.c
+@@ -14,6 +14,7 @@
+ #include <X11/keysym.h>
+ #include <X11/Xft/Xft.h>
+ #include <X11/XKBlib.h>
++#include <X11/Xresource.h>
+ 
+ char *argv0;
+ #include "arg.h"
+@@ -2011,6 +2012,118 @@ run(void)
+ 	}
+ }
+ 
++
++#define XRESOURCE_LOAD_META(NAME)					\
++	if(!XrmGetResource(xrdb, "st." NAME, "st." NAME, &type, &ret))	\
++		XrmGetResource(xrdb, "*." NAME, "*." NAME, &type, &ret); \
++	if (ret.addr != NULL && !strncmp("String", type, 64))
++
++#define XRESOURCE_LOAD_STRING(NAME, DST)	\
++	XRESOURCE_LOAD_META(NAME)		\
++		DST = ret.addr;
++
++#define XRESOURCE_LOAD_CHAR(NAME, DST)		\
++	XRESOURCE_LOAD_META(NAME)		\
++		DST = ret.addr[0];
++
++#define XRESOURCE_LOAD_INTEGER(NAME, DST)		\
++	XRESOURCE_LOAD_META(NAME)			\
++		DST = strtoul(ret.addr, NULL, 10);
++
++#define XRESOURCE_LOAD_FLOAT(NAME, DST)		\
++	XRESOURCE_LOAD_META(NAME)		\
++		DST = strtof(ret.addr, NULL);
++
++void
++xrdb_load(void)
++{
++	/* XXX */
++	char *xrm;
++	char *type;
++	XrmDatabase xrdb;
++	XrmValue ret;
++	Display *dpy;
++
++	if(!(dpy = XOpenDisplay(NULL)))
++		die("Can't open display\n");
++
++	XrmInitialize();
++	xrm = XResourceManagerString(dpy);
++
++	if (xrm != NULL) {
++		xrdb = XrmGetStringDatabase(xrm);
++
++		/* handling colors here without macros to do via loop. */
++		int i = 0;
++		char loadValue[12] = "";
++		for (i = 0; i < 256; i++)
++		{
++			sprintf(loadValue, "%s%d", "st.color", i);
++
++			if(!XrmGetResource(xrdb, loadValue, loadValue, &type, &ret))
++			{
++				sprintf(loadValue, "%s%d", "*.color", i);
++				if (!XrmGetResource(xrdb, loadValue, loadValue, &type, &ret))
++					/* reset if not found (unless in range for defaults). */
++					if (i > 15)
++						colorname[i] = NULL;
++			}
++
++			if (ret.addr != NULL && !strncmp("String", type, 64))
++				colorname[i] = ret.addr;
++		}
++
++		XRESOURCE_LOAD_STRING("foreground", colorname[defaultfg]);
++		XRESOURCE_LOAD_STRING("background", colorname[defaultbg]);
++		XRESOURCE_LOAD_STRING("cursorColor", colorname[defaultcs])
++		else {
++		  // this looks confusing because we are chaining off of the if
++		  // in the macro. probably we should be wrapping everything blocks
++		  // so this isn't possible...
++		  defaultcs = defaultfg;
++		}
++		XRESOURCE_LOAD_STRING("reverse-cursor", colorname[defaultrcs])
++		else {
++		  // see above.
++		  defaultrcs = defaultbg;
++		}
++
++		XRESOURCE_LOAD_STRING("font", font);
++		XRESOURCE_LOAD_STRING("termname", termname);
++
++		XRESOURCE_LOAD_INTEGER("blinktimeout", blinktimeout);
++		XRESOURCE_LOAD_INTEGER("bellvolume", bellvolume);
++		XRESOURCE_LOAD_INTEGER("borderpx", borderpx);
++		XRESOURCE_LOAD_INTEGER("cursorshape", cursorshape);
++
++		XRESOURCE_LOAD_FLOAT("cwscale", cwscale);
++		XRESOURCE_LOAD_FLOAT("chscale", chscale);
++	}
++	XFlush(dpy);
++}
++
++void
++reload(int sig)
++{
++	xrdb_load();
++
++	/* colors, fonts */
++	xloadcols();
++	xunloadfonts();
++	xloadfonts(font, 0);
++
++	/* pretend the window just got resized */
++	cresize(win.w, win.h);
++
++	redraw();
++
++	/* triggers re-render if we're visible. */
++	ttywrite("\033[O", 3, 1);
++
++	signal(SIGUSR1, reload);
++}
++
++
+ void
+ usage(void)
+ {
+@@ -2084,6 +2197,8 @@ run:
+ 
+ 	setlocale(LC_CTYPE, "");
+ 	XSetLocaleModifiers("");
++	xrdb_load();
++	signal(SIGUSR1, reload);
+ 	cols = MAX(cols, 1);
+ 	rows = MAX(rows, 1);
+ 	tnew(cols, rows);
+-- 
+2.35.1
+

--- a/x.c
+++ b/x.c
@@ -14,6 +14,7 @@
 #include <X11/keysym.h>
 #include <X11/Xft/Xft.h>
 #include <X11/XKBlib.h>
+#include <X11/Xresource.h>
 
 char *argv0;
 #include "arg.h"
@@ -2011,6 +2012,118 @@ run(void)
 	}
 }
 
+
+#define XRESOURCE_LOAD_META(NAME)					\
+	if(!XrmGetResource(xrdb, "st." NAME, "st." NAME, &type, &ret))	\
+		XrmGetResource(xrdb, "*." NAME, "*." NAME, &type, &ret); \
+	if (ret.addr != NULL && !strncmp("String", type, 64))
+
+#define XRESOURCE_LOAD_STRING(NAME, DST)	\
+	XRESOURCE_LOAD_META(NAME)		\
+		DST = ret.addr;
+
+#define XRESOURCE_LOAD_CHAR(NAME, DST)		\
+	XRESOURCE_LOAD_META(NAME)		\
+		DST = ret.addr[0];
+
+#define XRESOURCE_LOAD_INTEGER(NAME, DST)		\
+	XRESOURCE_LOAD_META(NAME)			\
+		DST = strtoul(ret.addr, NULL, 10);
+
+#define XRESOURCE_LOAD_FLOAT(NAME, DST)		\
+	XRESOURCE_LOAD_META(NAME)		\
+		DST = strtof(ret.addr, NULL);
+
+void
+xrdb_load(void)
+{
+	/* XXX */
+	char *xrm;
+	char *type;
+	XrmDatabase xrdb;
+	XrmValue ret;
+	Display *dpy;
+
+	if(!(dpy = XOpenDisplay(NULL)))
+		die("Can't open display\n");
+
+	XrmInitialize();
+	xrm = XResourceManagerString(dpy);
+
+	if (xrm != NULL) {
+		xrdb = XrmGetStringDatabase(xrm);
+
+		/* handling colors here without macros to do via loop. */
+		int i = 0;
+		char loadValue[12] = "";
+		for (i = 0; i < 256; i++)
+		{
+			sprintf(loadValue, "%s%d", "st.color", i);
+
+			if(!XrmGetResource(xrdb, loadValue, loadValue, &type, &ret))
+			{
+				sprintf(loadValue, "%s%d", "*.color", i);
+				if (!XrmGetResource(xrdb, loadValue, loadValue, &type, &ret))
+					/* reset if not found (unless in range for defaults). */
+					if (i > 15)
+						colorname[i] = NULL;
+			}
+
+			if (ret.addr != NULL && !strncmp("String", type, 64))
+				colorname[i] = ret.addr;
+		}
+
+		XRESOURCE_LOAD_STRING("foreground", colorname[defaultfg]);
+		XRESOURCE_LOAD_STRING("background", colorname[defaultbg]);
+		XRESOURCE_LOAD_STRING("cursorColor", colorname[defaultcs])
+		else {
+		  // this looks confusing because we are chaining off of the if
+		  // in the macro. probably we should be wrapping everything blocks
+		  // so this isn't possible...
+		  defaultcs = defaultfg;
+		}
+		XRESOURCE_LOAD_STRING("reverse-cursor", colorname[defaultrcs])
+		else {
+		  // see above.
+		  defaultrcs = defaultbg;
+		}
+
+		XRESOURCE_LOAD_STRING("font", font);
+		XRESOURCE_LOAD_STRING("termname", termname);
+
+		XRESOURCE_LOAD_INTEGER("blinktimeout", blinktimeout);
+		XRESOURCE_LOAD_INTEGER("bellvolume", bellvolume);
+		XRESOURCE_LOAD_INTEGER("borderpx", borderpx);
+		XRESOURCE_LOAD_INTEGER("cursorshape", cursorshape);
+
+		XRESOURCE_LOAD_FLOAT("cwscale", cwscale);
+		XRESOURCE_LOAD_FLOAT("chscale", chscale);
+	}
+	XFlush(dpy);
+}
+
+void
+reload(int sig)
+{
+	xrdb_load();
+
+	/* colors, fonts */
+	xloadcols();
+	xunloadfonts();
+	xloadfonts(font, 0);
+
+	/* pretend the window just got resized */
+	cresize(win.w, win.h);
+
+	redraw();
+
+	/* triggers re-render if we're visible. */
+	ttywrite("\033[O", 3, 1);
+
+	signal(SIGUSR1, reload);
+}
+
+
 void
 usage(void)
 {
@@ -2084,6 +2197,8 @@ run:
 
 	setlocale(LC_CTYPE, "");
 	XSetLocaleModifiers("");
+	xrdb_load();
+	signal(SIGUSR1, reload);
 	cols = MAX(cols, 1);
 	rows = MAX(rows, 1);
 	tnew(cols, rows);


### PR DESCRIPTION
Patch [xresources with signal reloading](https://st.suckless.org/patches/xresources-with-reload-signal/)

Applies:
- [st-xresources-signal-reloading-20220407-ef05519.diff](https://st.suckless.org/patches/xresources-with-reload-signal/st-xresources-signal-reloading-20220407-ef05519.diff)